### PR TITLE
Workflow fails when Inbox or Trash notebooks empty with a KeyError.

### DIFF
--- a/run.py
+++ b/run.py
@@ -107,6 +107,8 @@ def main(wf):
             if n == "Recents":
                 wf.add_item("Recents", autocomplete = "Recents", icon = icon)
             else:
+                # Default retrieval `notebook = n' with `count = 0' to prevent keyerror on empty Index / Trash
+                notebook = notebooks_q.get(n, {"notebook": n, "count": 0})
                 wf.add_item(notebooks_q[n]["notebook"], str(notebooks_q[n]["count"]) + " item(s)", autocomplete = n, icon = icon)
 
         if len(args) > 0:


### PR DESCRIPTION
When Inbox or Trash notebooks contain 0 entries, there is no corresponding key present in `notebooks_q`. When populating the workflow and `n` references an empty `"Inbox"` or `"Trash"`, it throws a KeyError.