### PR TITLE
Swapped reference to correct notebook variable

### DIFF
--- a/run.py
+++ b/run.py
@@ -109,7 +109,7 @@ def main(wf):
             else:
                 # Default retrieval `notebook = n' with `count = 0' to prevent keyerror on empty Index / Trash
                 notebook = notebooks_q.get(n, {"notebook": n, "count": 0})
-                wf.add_item(notebooks_q[n]["notebook"], str(notebooks_q[n]["count"]) + " item(s)", autocomplete = n, icon = icon)
+                wf.add_item(notebook["notebook"], str(notebook["count"]) + " item(s)", autocomplete = n, icon = icon)
 
         if len(args) > 0:
             # Perform Search!


### PR DESCRIPTION
This is a bit stupid, but I was cleaning my repos and saw it. Since the original change was only a small edit I just did it online. This is the correct version that I've been using in Alfred; the one before would create default fallback dictionaries but didn't actually pull the values from them. Fortunately no side effects to that little boo-boo. Sorry!