### PR TITLE
When storing notes to the database, process qvnotebook only

### DIFF
--- a/quiver_to_db.py
+++ b/quiver_to_db.py
@@ -68,7 +68,7 @@ def load_json(f):
 
 # Store notes
 with db.atomic():
-    for notebook in iglob(libpath + "/*"):
+    for notebook in iglob(libpath + "/*.qvnotebook"):
         meta = load_json(list(iglob(notebook + "/meta.json"))[0])
         nb_name = meta["name"]
 


### PR DESCRIPTION
Hi,

I have in my qvlibrary file `meta.json`, this change resolves issue #7 for me.